### PR TITLE
Added md5 checksum to ossec-agent chocolateyinstall.ps1

### DIFF
--- a/ossec-agent/tools/chocolateyInstall.ps1
+++ b/ossec-agent/tools/chocolateyInstall.ps1
@@ -3,7 +3,8 @@ $packageName    = 'ossec'
 $installerType  = 'exe'
 $url            = 'http://www.ossec.net/files/ossec-agent-win32-2.8.exe'
 $url64          = $url
+$checksum       = "a699117d0ed77f88b3a8661644ee3efd"
 $silentArgs     = '/S'
 $validExitCodes = @(0)
 
-Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" "$url64"  -validExitCodes $validExitCodes
+Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" "$url64" -checksum $checksum -validExitCodes $validExitCodes


### PR DESCRIPTION
In order to reduce the chance of malware install I've added an MD5 checksum to the ossec-agent install.
